### PR TITLE
Fix #4: Update bounds on change layout 

### DIFF
--- a/Classes/ZFRippleButton.swift
+++ b/Classes/ZFRippleButton.swift
@@ -9,6 +9,7 @@
 import UIKit
 import QuartzCore
 
+@IBDesignable
 class ZFRippleButton: UIButton {
   
   @IBInspectable var ripplePercent: Float = 0.8 {
@@ -46,11 +47,26 @@ class ZFRippleButton: UIButton {
   @IBInspectable var shadowRippleRadius: Float = 1
   @IBInspectable var shadowRippleEnable: Bool = true
   @IBInspectable var trackTouchLocation: Bool = false
+  @IBInspectable var buttonCornerRadius: Float = 0 {
+    didSet{
+            layer.mask = cornerRadiusMask
+        }
+   }
   
   let rippleView = UIView()
   let rippleBackgroundView = UIView()
   private var tempShadowRadius: CGFloat = 0
   private var tempShadowOpacity: Float = 0
+    
+  private var cornerRadiusMask:CAShapeLayer{
+    get{
+        let maskLayer = CAShapeLayer()
+        maskLayer.backgroundColor = UIColor.blackColor().CGColor
+        maskLayer.path = UIBezierPath(roundedRect: bounds, cornerRadius:CGFloat(buttonCornerRadius)).CGPath
+        return maskLayer
+    }
+  }
+    
   
   required init(coder aDecoder: NSCoder)  {
     super.init(coder: aDecoder)
@@ -163,6 +179,7 @@ class ZFRippleButton: UIButton {
     override func layoutSubviews() {
         super.layoutSubviews()
         self.rippleBackgroundView.frame = bounds
+        layer.mask = cornerRadiusMask
         setupRippleView()
     }
 

--- a/Demo/ZFRippleButtonDemo/ZFRippleButtonDemo/Base.lproj/Main.storyboard
+++ b/Demo/ZFRippleButtonDemo/ZFRippleButtonDemo/Base.lproj/Main.storyboard
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6245" systemVersion="13E28" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
     <dependencies>
-        <deployment defaultVersion="1808" identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6238"/>
     </dependencies>
     <scenes>
@@ -49,6 +48,9 @@
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="boolean" keyPath="trackTouchLocation" value="YES"/>
                                     <userDefinedRuntimeAttribute type="boolean" keyPath="rippleOverBounds" value="NO"/>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="buttonCornerRadius">
+                                        <real key="value" value="12"/>
+                                    </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0hN-TT-axH" customClass="ZFRippleButton" customModule="ZFRippleButtonDemo" customModuleProvider="target">


### PR DESCRIPTION
Hello first, I really like your button. I was having the same issue as #4 so I've overriden layoutSubviews to update the rippleView and the backgroundView frames. I've also added a corner radius property so as to have rounded buttons. What do you think? 

PS I updated the storyboard layout  to reflect this change when you rotate the view and made the class @IBDesignable to see the changes immediately.
PPS sorry for my bad english

![ios simulator screen shot 18 09 2014 10 29 01](https://cloud.githubusercontent.com/assets/2380325/4322645/3dea513a-3f4a-11e4-929a-00e43da56681.png)

![ios simulator screen shot 18 09 2014 10 29 06](https://cloud.githubusercontent.com/assets/2380325/4322652/4778fd1e-3f4a-11e4-8c01-8e828487f4c9.png)
