### PR TITLE
handle cancel event

### DIFF
--- a/Classes/ZFRippleButton.swift
+++ b/Classes/ZFRippleButton.swift
@@ -135,11 +135,19 @@ class ZFRippleButton: UIButton {
     }
     return super.beginTrackingWithTouch(touch, withEvent: event)
   }
+
+  override func cancelTrackingWithEvent(event: UIEvent?) {
+    super.cancelTrackingWithEvent(event)
+    animateToNormal()
+  }
   
   override func endTrackingWithTouch(touch: UITouch,
     withEvent event: UIEvent) {
     super.endTrackingWithTouch(touch, withEvent: event)
-    
+    animateToNormal()
+  }
+ 
+  private func animateToNormal(){
     UIView.animateWithDuration(0.1, animations: {
       self.rippleBackgroundView.alpha = 1
     }, completion: {(success: Bool) -> () in


### PR DESCRIPTION
I've been using this class for cells in a uitableview, and there are certain cases when the touch ends up cancelled instead of ended. This causes the button to get stuck a state as if it were permanently pressed down.

Consequently I took the code that handled an ended touch and overrode the cancel handler to perform the same action.