### PR TITLE
Fix bug: Autolayout causes the wrong center position of ripple view.

### DIFF
--- a/Classes/ZFRippleButton.swift
+++ b/Classes/ZFRippleButton.swift
@@ -46,6 +46,7 @@ class ZFRippleButton: UIButton {
     
     private var tempShadowRadius: CGFloat = 0
     private var tempShadowOpacity: Float = 0
+    private var touchCenterLocation: CGPoint?
     
     private var rippleMask: CAShapeLayer? {
         get {
@@ -97,7 +98,9 @@ class ZFRippleButton: UIButton {
     
     override func beginTrackingWithTouch(touch: UITouch, withEvent event: UIEvent?) -> Bool {
         if trackTouchLocation {
-            rippleView.center = touch.locationInView(self)
+            touchCenterLocation = touch.locationInView(self)
+        } else {
+            touchCenterLocation = nil
         }
         
         UIView.animateWithDuration(0.1,
@@ -180,9 +183,10 @@ class ZFRippleButton: UIButton {
     override func layoutSubviews() {
         super.layoutSubviews()
         
-        let oldCenter = rippleView.center
         setupRippleView()
-        rippleView.center = oldCenter
+        if let knownTouchCenterLocation = touchCenterLocation {
+            rippleView.center = knownTouchCenterLocation
+        }
         
         rippleBackgroundView.layer.frame = bounds
         rippleBackgroundView.layer.mask = rippleMask


### PR DESCRIPTION
This bug occurs under the following conditions:

1. Autolayout is used. (I use Stack View.)
2. Track touch location is off or default.

In event "layoutSubviews()", the old rippleView.center is kept in order to get touch location from event "beginTrackingWithTouch" when track touch location is enabled. However the center position is always changed when auto layout is used. When track touch location is off, the wrong center position is kept.